### PR TITLE
feat: add option to apply tag inheritance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: Test
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['*']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+      - run: yarn eslint
+      - run: yarn tsc

--- a/bin/index.js
+++ b/bin/index.js
@@ -9,6 +9,8 @@ runExit(
   class DefaultCommand extends Command {
     file = Option.String("--file,-f");
 
+    inherit = Option.Boolean("--apply-inheritance,-i");
+
     async execute() {
       const sdl = this.file
         ? await readFile(this.file, "utf-8")
@@ -19,7 +21,9 @@ runExit(
         process.exit(1);
       }
 
-      this.context.stdout.write(expandSchemaTag(sdl) + "\n");
+      this.context.stdout.write(
+        expandSchemaTag(sdl, { applyInheritance: this.inherit ?? false }) + "\n"
+      );
     }
   }
 );

--- a/index.test.js
+++ b/index.test.js
@@ -23,7 +23,7 @@ test("expanding schema tags", async () => {
       external: String @external
     }
 
-    interface C {
+    interface C @tag(name: "other") {
       b: String
     }
 
@@ -39,7 +39,7 @@ test("expanding schema tags", async () => {
     }
   `;
 
-  const actual = expandSchemaTag(sdl);
+  const actual = expandSchemaTag(sdl, { applyInheritance: false });
 
   expect(actual).toMatchInlineSnapshot(`
 "directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
@@ -61,7 +61,7 @@ type A implements C @tag(name: \\"other\\") {
   external: String @external
 }
 
-interface C {
+interface C @tag(name: \\"other\\") {
   b: String @tag(name: \\"mytag\\")
 }
 
@@ -102,25 +102,25 @@ test("fed2: expanding schema tags", async () => {
       external: String @external
     }
 
-    interface C {
+    interface C @tag(name: "other") {
       b: String
     }
 
     union D = A
 
-    enum Enum {
+    enum Enum @tag(name: "other") {
       X
       Y
     }
 
-    input I {
+    input I @tag(name: "other") {
       f: String
     }
 
     scalar JSON
   `;
 
-  const actual = expandSchemaTag(sdl);
+  const actual = expandSchemaTag(sdl, { applyInheritance: false });
 
   expect(actual).toMatchInlineSnapshot(`
 "extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@tag\\", \\"@external\\", \\"@provides\\"])
@@ -142,19 +142,180 @@ type A implements C @tag(name: \\"other\\") {
   external: String @external
 }
 
-interface C {
+interface C @tag(name: \\"other\\") {
   b: String @tag(name: \\"mytag\\")
 }
 
 union D @tag(name: \\"mytag\\") = A
 
-enum Enum {
+enum Enum @tag(name: \\"other\\") {
   X @tag(name: \\"mytag\\")
   Y @tag(name: \\"mytag\\")
 }
 
-input I {
+input I @tag(name: \\"other\\") {
   f: String @tag(name: \\"mytag\\")
+}
+
+scalar JSON @tag(name: \\"mytag\\")"
+`);
+});
+
+test("--inherit", async () => {
+  const sdl = `#graphql
+    extend schema @tag(name: "mytag")
+
+    directive @tag(name: String!) on SCHEMA | OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+    type Query {
+      a: A
+    }
+
+    type Mutation {
+      c: C
+    }
+
+    type Subscription {
+      d: D
+    }
+
+    type A implements C @tag(name: "other") {
+      b: String @tag(name: "another")
+      external: String @external
+    }
+
+    interface C @tag(name: "other") {
+      b: String
+    }
+
+    union D = A
+
+    enum Enum {
+      X
+      Y
+    }
+
+    input I {
+      f: String
+    }
+  `;
+
+  const actual = expandSchemaTag(sdl, { applyInheritance: true });
+
+  expect(actual).toMatchInlineSnapshot(`
+"directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+type Query {
+  a: A @tag(name: \\"mytag\\")
+}
+
+type Mutation {
+  c: C @tag(name: \\"mytag\\")
+}
+
+type Subscription {
+  d: D @tag(name: \\"mytag\\")
+}
+
+type A implements C {
+  b: String @tag(name: \\"another\\") @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+  external: String @external
+}
+
+interface C {
+  b: String @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+}
+
+union D @tag(name: \\"mytag\\") = A
+
+enum Enum {
+  X
+  Y
+}
+
+input I {
+  f: String
+}"
+`);
+});
+
+test("fed2: --inherit", async () => {
+  const sdl = `#graphql
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.0"
+            import: ["@tag" "@external" "@provides"])
+      @tag(name: "mytag")
+
+    type Query {
+      a: A @provides(fields: "external")
+    }
+
+    type Mutation {
+      c: C
+    }
+
+    type Subscription {
+      d: D
+    }
+
+    type A implements C @tag(name: "other") {
+      b: String @tag(name: "another")
+      external: String @external
+    }
+
+    interface C @tag(name: "other") {
+      b: String
+    }
+
+    union D = A
+
+    enum Enum @tag(name: "other") {
+      X
+      Y
+    }
+
+    input I @tag(name: "other") {
+      f: String
+    }
+
+    scalar JSON
+  `;
+
+  const actual = expandSchemaTag(sdl, { applyInheritance: true });
+
+  expect(actual).toMatchInlineSnapshot(`
+"extend schema @link(url: \\"https://specs.apollo.dev/federation/v2.0\\", import: [\\"@tag\\", \\"@external\\", \\"@provides\\"])
+
+type Query {
+  a: A @provides(fields: \\"external\\") @tag(name: \\"mytag\\")
+}
+
+type Mutation {
+  c: C @tag(name: \\"mytag\\")
+}
+
+type Subscription {
+  d: D @tag(name: \\"mytag\\")
+}
+
+type A implements C {
+  b: String @tag(name: \\"another\\") @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+  external: String @external
+}
+
+interface C {
+  b: String @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+}
+
+union D @tag(name: \\"mytag\\") = A
+
+enum Enum {
+  X @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+  Y @tag(name: \\"mytag\\") @tag(name: \\"other\\")
+}
+
+input I {
+  f: String @tag(name: \\"mytag\\") @tag(name: \\"other\\")
 }
 
 scalar JSON @tag(name: \\"mytag\\")"


### PR DESCRIPTION
by passing `--inherit`, tags on objects/interfaces/inputs/enums will be moved to the fields/values. this reduces the blast radius of tagged objects. if a subgraph tags an object, then that object gets the tag in the supergraph. the contract filter then applies inheritance rules for fields/enums. this means that one subgraph can affect fields/values from other subgraphs.